### PR TITLE
Task_9 - DELETE /api/comments/:comment_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -147,19 +147,19 @@ describe("PATCH /api/articles/:article_id", () => {
         expect(_body.msg).toBe("Bad Request: Invalid Input");
       });
   });
-});
 
-test("PATCH:400 - responds with a 400 status code and relevant error message when sent an invalid vote Object", () => {
-  const testVote4 = {
-    inc_gold_stars : "5 bajillion"
-  }
-  return request(app)
-    .patch("/api/articles/5")
-    .send(testVote4)
-    .expect(400)
-    .then(({ _body }) => {
-      expect(_body.msg).toBe("Invalid vote object recieved!");
-    });
+  test("PATCH:400 - responds with a 400 status code and relevant error message when sent an invalid vote Object", () => {
+    const testVote4 = {
+      inc_gold_stars : "5 bajillion"
+    }
+    return request(app)
+      .patch("/api/articles/5")
+      .send(testVote4)
+      .expect(400)
+      .then(({ _body }) => {
+        expect(_body.msg).toBe("Invalid vote object recieved!");
+      });
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {
@@ -281,6 +281,35 @@ describe("POST /api/articles/:article_id/comments", () => {
     return request(app)
       .post("/api/articles/;DROP TABLE comments;/comments")
       .send(testComment5)
+      .expect(400)
+      .then(({ _body }) => {
+        expect(_body.msg).toBe("Bad Request: Invalid Input");
+      });
+  });
+});
+
+describe("DELETE /api/comments/:comment_id", () => {
+  test("DELETE:204 - responds with a 204 and no content", () => {
+    return request(app)
+      .delete("/api/comments/5")
+      .expect(204)
+      .then(({_body}) => {
+        expect(!_body);
+      });
+  });
+
+  test("DELETE:404 - responds with a 404 and relevant error message when supplied a non-existing comment_id ", () => {
+    return request(app)
+      .delete("/api/comments/789")
+      .expect(404)
+      .then(({_body}) => {
+        expect(_body.msg).toBe('Comment with that Id does not exist!')
+      });
+  });
+
+  test("DELETE:400 - responds with a 400 status code and relevant error message when supplied with an invalid article_id", () => {
+    return request(app)
+      .delete("/api/comments/;DROP TABLE comments;")
       .expect(400)
       .then(({ _body }) => {
         expect(_body.msg).toBe("Bad Request: Invalid Input");

--- a/app.js
+++ b/app.js
@@ -9,7 +9,8 @@ const {
 } = require("./controllers/articles.controllers")
 const {
     getCommentsByArticleId,
-    postCommentByArticleId
+    postCommentByArticleId,
+    srvDeleteCommentByCommentId
 } = require("./controllers/comments.controllers")
 const {handleCustomErrors, handlePsqlErrors} = require("./errors");
 
@@ -29,7 +30,7 @@ app.get("/api/articles/:article_id/comments", getCommentsByArticleId)
 
 app.post("/api/articles/:article_id/comments", postCommentByArticleId)
 
-
+app.delete("/api/comments/:comment_id", srvDeleteCommentByCommentId)
 
 app.all("*",catchAll)
 

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -2,6 +2,7 @@ const { forEach } = require("../db/data/test-data/articles");
 const {
   selectCommentsByArticleId,
   insertCommentByArticleId,
+  dbDeleteCommentByCommentId
 } = require("../models/comments.models");
 const {
   checkCommentFormat,
@@ -71,3 +72,19 @@ exports.getCommentsByArticleId = ({ params: { article_id } }, res, next) => {
       })
       .catch(next);
   };
+
+exports.srvDeleteCommentByCommentId = ({params : {comment_id}},res,next) => {
+
+  return dbDeleteCommentByCommentId(comment_id)
+  .then(({rows : deletedCommentRow})=>{
+    if(deletedCommentRow.length){
+      res.status(204).send();
+    }else{
+      return Promise.reject({
+        status: 404,
+        msg: "Comment with that Id does not exist!",
+      });
+    }
+  })
+  .catch(next)
+}

--- a/endpoints.json
+++ b/endpoints.json
@@ -102,5 +102,9 @@
       "votes": 0,
       "created_at": "2023-11-22T06:55:04.454Z"
     }
+  },
+  "DELETE /api/comments/:comment_id": {
+    "description": "deletes a single comment from the database, giving a 204 status code as confirmation of deletion. If deletion is successful, it should serve no content",
+    "exampleQuery": 5
   }
 }

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -19,3 +19,10 @@ exports.insertCommentByArticleId = ({username,body}, article_id) => {
         )
   }
   
+exports.dbDeleteCommentByCommentId = (comment_id) => {
+  return db.query(`
+  DELETE FROM comments
+  WHERE comment_id = $1
+  RETURNING *;`,
+  [comment_id])
+}


### PR DESCRIPTION
### Task_9 - DELETE /api/comments/:comment_id
_adds functionality to DELETE /api/comments/:comment_id, to enable deletion of comments by comment_id_
            - adds srvDeleteCommentByCommentId() to controllers and dbDeleteCommentByCommentId() to models.
            - adds error handling to check for DELETING comments with...
              > non-existant comment_id
              > invalid comment_id
            - updated endpoints.json to reflect these changes